### PR TITLE
1D, 2D and 3D generic KH setup.

### DIFF
--- a/tests/hd/KH-ND/amrvac1D.par
+++ b/tests/hd/KH-ND/amrvac1D.par
@@ -1,0 +1,58 @@
+ !$AMRVAC_DIR/setup.pl -d=3
+
+ &filelist
+   base_filename    = 'output1D/kh'
+   autoconvert      = F
+   convert_type     = 'vtuBCCmpi'
+   saveprim         = T
+ /
+
+ &savelist
+   itsave(1,1)      = 0
+   itsave(1,2)      = 0
+   ditsave_log      = 1
+   dtsave_dat       = 1e10
+ /
+
+ &stoplist
+   it_max           = 20
+ /
+
+ &methodlist
+   time_stepper = 'twostep'
+   flux_scheme     = 20*'tvdlf'
+   limiter         = 20*'vanleer'
+   small_values_method = 'ignore'
+ /
+
+ &boundlist
+   typeboundary_min1 = 5*'periodic'
+   typeboundary_max1 = 5*'periodic'
+   typeboundary_min2 = 5*'periodic'
+   typeboundary_max2 = 5*'periodic'
+   typeboundary_min3 = 5*'periodic'
+   typeboundary_max3 = 5*'periodic'
+ /
+
+ &meshlist
+   refine_max_level   = 1
+   block_nx1          = 16
+   block_nx2          = 0
+   block_nx3          = 0
+   domain_nx1         = 64
+   domain_nx2         = 64
+   domain_nx3         = 64
+   xprobmin1       = 0.0d0
+   xprobmax1       = 1.0d0
+   xprobmin2       = 0.0d0
+   xprobmax2       = 1.0d0
+   xprobmin3       = 0.0d0
+   xprobmax3       = 1.0d0
+   iprob=1
+ /
+
+ &paramlist
+   slowsteps        = 10
+   courantpar       = 0.7d0
+   typecourant      = 'maxsum'
+ /

--- a/tests/hd/KH-ND/amrvac2D.par
+++ b/tests/hd/KH-ND/amrvac2D.par
@@ -1,0 +1,58 @@
+ !$AMRVAC_DIR/setup.pl -d=3
+
+ &filelist
+   base_filename    = 'output2D/kh'
+   autoconvert      = F
+   convert_type     = 'vtuBCCmpi'
+   saveprim         = T
+ /
+
+ &savelist
+   itsave(1,1)      = 0
+   itsave(1,2)      = 0
+   ditsave_log      = 1
+   dtsave_dat       = 1e10
+ /
+
+ &stoplist
+   it_max           = 20
+ /
+
+ &methodlist
+   time_stepper = 'twostep'
+   flux_scheme     = 20*'tvdlf'
+   limiter         = 20*'vanleer'
+   small_values_method = 'ignore'
+ /
+
+ &boundlist
+   typeboundary_min1 = 5*'periodic'
+   typeboundary_max1 = 5*'periodic'
+   typeboundary_min2 = 5*'periodic'
+   typeboundary_max2 = 5*'periodic'
+   typeboundary_min3 = 5*'periodic'
+   typeboundary_max3 = 5*'periodic'
+ /
+
+ &meshlist
+   refine_max_level   = 1
+   block_nx1          = 16
+   block_nx2          = 16
+   block_nx3          = 0
+   domain_nx1         = 64
+   domain_nx2         = 64
+   domain_nx3         = 64
+   xprobmin1       = 0.0d0
+   xprobmax1       = 1.0d0
+   xprobmin2       = 0.0d0
+   xprobmax2       = 1.0d0
+   xprobmin3       = 0.0d0
+   xprobmax3       = 1.0d0
+   iprob=1
+ /
+
+ &paramlist
+   slowsteps        = 10
+   courantpar       = 0.7d0
+   typecourant      = 'maxsum'
+ /

--- a/tests/hd/KH-ND/amrvac3D.par
+++ b/tests/hd/KH-ND/amrvac3D.par
@@ -1,0 +1,58 @@
+ !$AMRVAC_DIR/setup.pl -d=3
+
+ &filelist
+   base_filename    = 'output3D/kh'
+   autoconvert      = T
+   convert_type     = 'vtuBCCmpi'
+   saveprim         = T
+ /
+
+ &savelist
+   itsave(1,1)      = 0
+   itsave(1,2)      = 0
+   ditsave_log      = 1
+   dtsave_dat       = 1e10
+ /
+
+ &stoplist
+   it_max           = 20
+ /
+
+ &methodlist
+   time_stepper = 'twostep'
+   flux_scheme     = 20*'tvdlf'
+   limiter         = 20*'vanleer'
+   small_values_method = 'ignore'
+ /
+
+ &boundlist
+   typeboundary_min1 = 5*'periodic'
+   typeboundary_max1 = 5*'periodic'
+   typeboundary_min2 = 5*'periodic'
+   typeboundary_max2 = 5*'periodic'
+   typeboundary_min3 = 5*'periodic'
+   typeboundary_max3 = 5*'periodic'
+ /
+
+ &meshlist
+   refine_max_level   = 1
+   block_nx1          = 16
+   block_nx2          = 16
+   block_nx3          = 16
+   domain_nx1         = 64
+   domain_nx2         = 64
+   domain_nx3         = 64
+   xprobmin1       = 0.0d0
+   xprobmax1       = 1.0d0
+   xprobmin2       = 0.0d0
+   xprobmax2       = 1.0d0
+   xprobmin3       = 0.0d0
+   xprobmax3       = 1.0d0
+   iprob=1
+ /
+
+ &paramlist
+   slowsteps        = 10
+   courantpar       = 0.7d0
+   typecourant      = 'maxsum'
+ /

--- a/tests/hd/KH-ND/convert1D.par
+++ b/tests/hd/KH-ND/convert1D.par
@@ -1,0 +1,59 @@
+ !$AMRVAC_DIR/setup.pl -d=3
+
+ &filelist
+   base_filename    = 'output1D/kh'
+   convert          = T
+   convert_type     = 'oneblock'
+   saveprim         = T
+   level_io         = 1
+ /
+
+ &savelist
+   itsave(1,1)      = 0
+   itsave(1,2)      = 0
+   ditsave_log      = 1
+   dtsave_dat       = 1e10
+ /
+
+ &stoplist
+   it_max           = 20
+ /
+
+ &methodlist
+   time_stepper = 'twostep'
+   flux_scheme     = 20*'tvdlf'
+   limiter         = 20*'vanleer'
+   small_values_method = 'ignore'
+ /
+
+ &boundlist
+   typeboundary_min1 = 5*'periodic'
+   typeboundary_max1 = 5*'periodic'
+   typeboundary_min2 = 5*'periodic'
+   typeboundary_max2 = 5*'periodic'
+   typeboundary_min3 = 5*'periodic'
+   typeboundary_max3 = 5*'periodic'
+ /
+
+ &meshlist
+   refine_max_level   = 1
+   block_nx1          = 16
+   block_nx2          = 0
+   block_nx3          = 0
+   domain_nx1         = 64
+   domain_nx2         = 64
+   domain_nx3         = 64
+   xprobmin1       = 0.0d0
+   xprobmax1       = 1.0d0
+   xprobmin2       = 0.0d0
+   xprobmax2       = 1.0d0
+   xprobmin3       = 0.0d0
+   xprobmax3       = 1.0d0
+   iprob=1
+ /
+
+ &paramlist
+   slowsteps        = 10
+   courantpar       = 0.7d0
+   typecourant      = 'maxsum'
+ /

--- a/tests/hd/KH-ND/convert2D.par
+++ b/tests/hd/KH-ND/convert2D.par
@@ -1,0 +1,59 @@
+ !$AMRVAC_DIR/setup.pl -d=3
+
+ &filelist
+   base_filename    = 'output2D/kh'
+   convert          = T
+   convert_type     = 'oneblock'
+   saveprim         = T
+   level_io         = 1
+ /
+
+ &savelist
+   itsave(1,1)      = 0
+   itsave(1,2)      = 0
+   ditsave_log      = 1
+   dtsave_dat       = 1e10
+ /
+
+ &stoplist
+   it_max           = 20
+ /
+
+ &methodlist
+   time_stepper = 'twostep'
+   flux_scheme     = 20*'tvdlf'
+   limiter         = 20*'vanleer'
+   small_values_method = 'ignore'
+ /
+
+ &boundlist
+   typeboundary_min1 = 5*'periodic'
+   typeboundary_max1 = 5*'periodic'
+   typeboundary_min2 = 5*'periodic'
+   typeboundary_max2 = 5*'periodic'
+   typeboundary_min3 = 5*'periodic'
+   typeboundary_max3 = 5*'periodic'
+ /
+
+ &meshlist
+   refine_max_level   = 1
+   block_nx1          = 16
+   block_nx2          = 16
+   block_nx3          = 0
+   domain_nx1         = 64
+   domain_nx2         = 64
+   domain_nx3         = 64
+   xprobmin1       = 0.0d0
+   xprobmax1       = 1.0d0
+   xprobmin2       = 0.0d0
+   xprobmax2       = 1.0d0
+   xprobmin3       = 0.0d0
+   xprobmax3       = 1.0d0
+   iprob=1
+ /
+
+ &paramlist
+   slowsteps        = 10
+   courantpar       = 0.7d0
+   typecourant      = 'maxsum'
+ /

--- a/tests/hd/KH-ND/convert3D.par
+++ b/tests/hd/KH-ND/convert3D.par
@@ -1,0 +1,59 @@
+ !$AMRVAC_DIR/setup.pl -d=3
+
+ &filelist
+   base_filename    = 'output3D/kh'
+   convert          = T
+   convert_type     = 'oneblock'
+   saveprim         = T
+   level_io         = 1
+ /
+
+ &savelist
+   itsave(1,1)      = 0
+   itsave(1,2)      = 0
+   ditsave_log      = 1
+   dtsave_dat       = 1e10
+ /
+
+ &stoplist
+   it_max           = 20
+ /
+
+ &methodlist
+   time_stepper = 'twostep'
+   flux_scheme     = 20*'tvdlf'
+   limiter         = 20*'vanleer'
+   small_values_method = 'ignore'
+ /
+
+ &boundlist
+   typeboundary_min1 = 5*'periodic'
+   typeboundary_max1 = 5*'periodic'
+   typeboundary_min2 = 5*'periodic'
+   typeboundary_max2 = 5*'periodic'
+   typeboundary_min3 = 5*'periodic'
+   typeboundary_max3 = 5*'periodic'
+ /
+
+ &meshlist
+   refine_max_level   = 1
+   block_nx1          = 16
+   block_nx2          = 16
+   block_nx3          = 16
+   domain_nx1         = 64
+   domain_nx2         = 64
+   domain_nx3         = 64
+   xprobmin1       = 0.0d0
+   xprobmax1       = 1.0d0
+   xprobmin2       = 0.0d0
+   xprobmax2       = 1.0d0
+   xprobmin3       = 0.0d0
+   xprobmax3       = 1.0d0
+   iprob=1
+ /
+
+ &paramlist
+   slowsteps        = 10
+   courantpar       = 0.7d0
+   typecourant      = 'maxsum'
+ /

--- a/tests/hd/KH-ND/mod_usr.t
+++ b/tests/hd/KH-ND/mod_usr.t
@@ -1,0 +1,95 @@
+module mod_usr
+  use mod_hd
+
+  implicit none
+
+  double precision :: rhodens  = 10.0d0
+  double precision :: rholight = 1.0d0
+  double precision :: kx       = 4.0d0 * acos(-1.0d0)
+  double precision :: kz       = 32d0*atan(1.0d0)
+  double precision :: pint     = 2.5d0
+  double precision :: dlin     = 0.025d0
+  double precision :: sigma    = 0.00125d0
+
+contains
+
+  subroutine usr_init()
+
+    call set_coordinate_system("Cartesian_3D")
+
+    usr_init_one_grid => initonegrid_usr
+
+    call hd_activate()
+
+  end subroutine usr_init
+
+  subroutine initonegrid_usr(ixG^L,ix^L,w,x)
+    integer, intent(in)             :: ixG^L, ix^L
+    double precision, intent(in)    :: x(ixG^S,1:ndim)
+    double precision, intent(inout) :: w(ixG^S,1:nw)
+    double precision                :: vextra
+    
+    select case(iprob)
+    case(1)
+       vextra=0.0d0
+    case(2)
+       vextra = 10.0d0
+    case(3)
+       vextra=100.0d0
+    case default
+       error stop "Unknown iprob"
+    endselect
+
+
+    if (userdim > 1) then ! 2D and 3D case
+
+       where(x(ixG^S,2)<0.25d0.or.x(ixG^S,2)>0.75d0)
+          w(ixG^S,rho_)=rholight
+       elsewhere
+          w(ixG^S,rho_)=rhodens
+       endwhere
+
+       w(ixG^S,p_)=pint
+
+       where((x(ixG^S,2)<=(0.25d0-dlin)).or.(x(ixG^S,2)>=(0.75d0+dlin)))
+          w(ixG^S,mom(1))=vextra-0.5d0
+       endwhere
+
+       where((x(ixG^S,2)>=(0.25d0+dlin)).and.(x(ixG^S,2)<=(0.75d0-dlin)))
+          w(ixG^S,mom(1))=vextra+0.5d0
+       endwhere
+
+       where((x(ixG^S,2)>(0.25d0-dlin)).and.(x(ixG^S,2)<(0.25d0+dlin)))
+          w(ixG^S,mom(1))=(x(ixG^S,2)-(0.25d0-dlin))* &
+               ((vextra+0.5d0)-(vextra-0.5d0))/(2.0d0*dlin)+(vextra-0.5d0)
+       endwhere
+
+       where((x(ixG^S,2)>(0.75d0-dlin)).and.(x(ixG^S,2)<(0.75d0+dlin)))
+          w(ixG^S,mom(1))=(x(ixG^S,2)-(0.75d0-dlin))* &
+               ((vextra-0.5d0)-(vextra+0.5d0))/(2.0d0*dlin)+(vextra+0.5d0)
+       endwhere
+
+       w(ixG^S,mom(2))=0.01d0*dsin(kx*x(ixG^S,1))* &
+            (dexp(-0.5d0*(x(ixG^S,2)-0.25d0)**2/sigma)+dexp(-0.5d0*(x(ixG^S,2)-0.75d0)**2/sigma))
+
+       if (userdim > 2) then ! 3D
+          w(ixG^S,mom(3))=0.1d0*dsin(kz*x(ixG^S,3))* &
+               (dexp(-0.5d0*(x(ixG^S,2)-0.25d0)**2/sigma)+dexp(-0.5d0*(x(ixG^S,2)-0.75d0)**2/sigma))
+       else ! 2D
+          w(ixG^S,mom(3)) = 0.0d0
+       end if
+
+
+    else ! handle 1D case (just a constant flow to have something well defined here
+       w(ixG^S,rho_)   = rhodens
+       w(ixG^S,p_)     = pint
+       w(ixG^S,mom(1)) = vextra
+       w(ixG^S,mom(2)) = 0.0d0
+       w(ixG^S,mom(3)) = 0.0d0
+    end if
+
+    call hd_to_conserved(ixG^L,ix^L,w,x)
+
+  end subroutine initonegrid_usr
+
+end module mod_usr


### PR DESCRIPTION
you can convert the dat files to simple oneblock ascii data using e.g. ./amrvac -i convert1D.par -if output1D/kh0001.dat

I loaded up the 2D version with numpy loadtext (skiprows=3). Then you can reshape to (64,64,8) and imshow.
It looked fine (but I'm not sure whether I looked at converved or primitive variables)